### PR TITLE
Pragma bug fix/enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,28 @@ module: {
 
 Then import and use your components as you'd do with standard JavaScript!
 
+You may also specify options in Webpack config:
+
+```js
+module: {
+  rules: [
+    { test: /\.mdx?$/,
+      use: [
+        'babel-loader',
+        {
+          loader: 'mdx-loader',
+          options: {
+            pragma: 'h',
+            imports: [
+              'import h from \'h\''
+            ]
+          }
+      ]
+    }
+  ]
+}
+```
+
 ### API
 
 At its core, MDXC is just a wrapper around the excellent and highly configurable [markdown-it](https://github.com/markdown-it/markdown-it) project. This means that its API is mostly the same.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "mdx"
   ],
   "devDependencies": {
+    "babel-cli": "^6.24.1",
     "babel-plugin-transform-class-properties": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "babel-preset-latest": "^6.22.0",
@@ -40,6 +41,7 @@
     "prismjs": "^1.6.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
+    "rimraf": "^2.6.1",
     "sitepack": "^1.0.0-beta.4",
     "sitepack-react": "^1.0.0-beta.7"
   },

--- a/site/loaders/mdx-loader.js
+++ b/site/loaders/mdx-loader.js
@@ -63,6 +63,12 @@ module.exports = function mdxLoader(content) {
       .enable(['link'])
       .use(mdImageReplacer)
 
+  if (loaderOptions.pragma) {
+    Object.assign(md.factories, {
+      codeBlock: '(props, children) => '+loaderOptions.pragma+'("pre", props, '+loaderOptions.pragma+'("code", { dangerouslySetInnerHTML: { __html: children || props.children } }))'
+    })
+  }
+
   const data = frontMatter(content);
   const body = md.render(data.body, env);
   return body + `\nexport const meta = ${JSON.stringify(data.attributes, null, 2)}`

--- a/source/mdxc.js
+++ b/source/mdxc.js
@@ -65,6 +65,9 @@ function mdAnchor(md) {
   })
 }
 
+function makeArray(stringOrArray) {
+  return Array.isArray(stringOrArray) ? stringOrArray : [stringOrArray]
+}
 
 module.exports = class MDXC extends MarkdownIt {
   constructor (options={}) {
@@ -126,10 +129,13 @@ module.exports = class MDXC extends MarkdownIt {
   render(body, env) {
     env = env || {};
 
-    let importsSource = [`import React, { createElement, createFactory } from 'react'`]
-    const optionImports = Array.isArray(this.options.imports) ? this.options.imports : [this.options.imports]
+    let importsSource = []
+    if (!this.options.pragma) {
+      importsSource.push(`import React, { createElement, createFactory } from 'react'`)
+    }
+
     if (this.options.imports) {
-      importsSource = importsSource.concat(this.options.imports)
+      importsSource = importsSource.concat(makeArray(this.options.imports))
     }
 
     const rendered = this.renderer.render(this.parse(body, env), this.options, env).trim();

--- a/source/mdxc.js
+++ b/source/mdxc.js
@@ -126,10 +126,7 @@ module.exports = class MDXC extends MarkdownIt {
   render(body, env) {
     env = env || {};
 
-    let importsSource = ''
-    if (!this.options.pragma) {
-      importsSource += `import React, { createElement, createFactory } from 'react'\n`
-    }
+    let importsSource = `import React, { createElement, createFactory } from 'react'\n`
 
     const rendered = this.renderer.render(this.parse(body, env), this.options, env).trim();
     const result = rendered === '' ? 'wrapper({})' : `wrapper({},\n\n${rendered}\n\n  )`

--- a/source/mdxc.js
+++ b/source/mdxc.js
@@ -126,17 +126,23 @@ module.exports = class MDXC extends MarkdownIt {
   render(body, env) {
     env = env || {};
 
-    let importsSource = `import React, { createElement, createFactory } from 'react'\n`
+    let importsSource = [`import React, { createElement, createFactory } from 'react'`]
+    const optionImports = Array.isArray(this.options.imports) ? this.options.imports : [this.options.imports]
+    if (this.options.imports) {
+      importsSource = importsSource.concat(this.options.imports)
+    }
 
     const rendered = this.renderer.render(this.parse(body, env), this.options, env).trim();
     const result = rendered === '' ? 'wrapper({})' : `wrapper({},\n\n${rendered}\n\n  )`
-    importsSource += `${this.imports}${this.imports ? '\n' : ''}`
+    importsSource = importsSource.concat(this.imports.split('\n'))
+
     const isCommonJS = !!this.options.commonJS
     const imports =
       !isCommonJS
-        ? importsSource
-        : importsToCommonJS(importsSource)
+        ? importsSource.join('\n')
+        : importsToCommonJS(importsSource.join('\n'))
     const tags = Array.from(this.renderer.tags.values()).sort()
+    
     return this.options.unwrapped ? rendered+'\n' : `${imports}
 ${isCommonJS ? 'module.exports =' : 'export default'} function({ ${this.props.join(', ') } }) {
   const {

--- a/test/fixtures/imports/imports.txt
+++ b/test/fixtures/imports/imports.txt
@@ -1,0 +1,50 @@
+.
+<Test test={1}>
+  <AnotherTest />
+</Test>
+.
+import h from 'h'
+
+export default function({ factories={} }) {
+  const {
+    wrapper = createFactory('div'),
+  } = factories
+
+  return wrapper({},
+
+h(
+  Test,
+  { test: 1 },
+  h(AnotherTest, null)
+)
+
+  )
+}
+.
+
+
+.
+import foo from 'foo'
+
+<Test test={1}>
+  <AnotherTest />
+</Test>
+.
+import h from 'h'
+import foo from 'foo'
+export default function({ factories={} }) {
+  const {
+    wrapper = createFactory('div'),
+  } = factories
+
+  return wrapper({},
+
+h(
+  Test,
+  { test: 1 },
+  h(AnotherTest, null)
+)
+
+  )
+}
+.

--- a/test/fixtures/importsArray/importsArray.txt
+++ b/test/fixtures/importsArray/importsArray.txt
@@ -1,0 +1,52 @@
+.
+<Test test={1}>
+  <AnotherTest />
+</Test>
+.
+import h from 'h'
+import bar from 'bar'
+
+export default function({ factories={} }) {
+  const {
+    wrapper = createFactory('div'),
+  } = factories
+
+  return wrapper({},
+
+h(
+  Test,
+  { test: 1 },
+  h(AnotherTest, null)
+)
+
+  )
+}
+.
+
+
+.
+import foo from 'foo'
+
+<Test test={1}>
+  <AnotherTest />
+</Test>
+.
+import h from 'h'
+import bar from 'bar'
+import foo from 'foo'
+export default function({ factories={} }) {
+  const {
+    wrapper = createFactory('div'),
+  } = factories
+
+  return wrapper({},
+
+h(
+  Test,
+  { test: 1 },
+  h(AnotherTest, null)
+)
+
+  )
+}
+.

--- a/test/fixtures/pragma/pragma.txt
+++ b/test/fixtures/pragma/pragma.txt
@@ -6,7 +6,6 @@ import h from 'h'
 </Test>
 .
 import h from 'h'
-
 export default function({ factories={} }) {
   const {
     wrapper = createFactory('div'),

--- a/test/fixtures/wrapped/import.txt
+++ b/test/fixtures/wrapped/import.txt
@@ -3,7 +3,6 @@ import Test from './test'
 .
 import React, { createElement, createFactory } from 'react'
 import Test from './test'
-
 export default function({ factories={} }) {
   const {
     wrapper = createFactory('div'),

--- a/test/mdxc.test.js
+++ b/test/mdxc.test.js
@@ -26,4 +26,25 @@ describe('mdxc', function () {
   })
 
   generate(path.join(__dirname, 'fixtures/pragma'), mdxPragma);
+
+  var mdxImports = new MDXC({
+    linkify: true,
+    typographer: true,
+    pragma: 'h',
+    imports: 'import h from \'h\''
+  })
+
+  generate(path.join(__dirname, 'fixtures/imports'), mdxImports);
+
+  var mdxImportsArray = new MDXC({
+    linkify: true,
+    typographer: true,
+    pragma: 'h',
+    imports: [
+      'import h from \'h\'',
+      'import bar from \'bar\''
+    ]
+  })
+
+  generate(path.join(__dirname, 'fixtures/importsArray'), mdxImportsArray);  
 });


### PR DESCRIPTION
This PR includes the following:

* Fix broken build. Previously the build would only work if `babel-cli` and `rimraf` were installed globally.
* Fix broken `pragma` feature. Previously, when a `prama` option was specified, `createFactory` was undefined.
* Add `this.options.imports` feature, enabling user to specify an import statement (or array of imports)
