### PR TITLE
Changes mdx-loader to check for prism language before trying to dynamically require the corresponding language file.

### DIFF
--- a/packages/mdx-loader/index.js
+++ b/packages/mdx-loader/index.js
@@ -22,8 +22,8 @@ function highlight(str, lang) {
     return str
   } else {
     lang = aliases[lang] || lang
-    require(`prismjs/components/prism-${lang}.js`)
     if (Prism.languages[lang]) {
+      require(`prismjs/components/prism-${lang}.js`)
       return Prism.highlight(str, Prism.languages[lang])
     } else {
       return str


### PR DESCRIPTION
Currently, if someone tries to do a code block in a markdown file with an unknown language to prism, like so...

````
# my-markdown-file

```x
var i = 0;
```
````

...mdxc-loader will be unhappy and will throw an error trying to load the corresponding language file.

```
Module build failed: Error: Cannot find module 'prismjs/components/prism-x.js' 
```

You can see the error happing on the MDXC demo site by removing the language from a code block.

![mdxc-code-block-unknown-language](https://user-images.githubusercontent.com/446260/38970220-ccea36ae-4359-11e8-9d00-d0d95555ddda.gif)

The error can be avoided if the dynamic require is tucked into the check of available prism languages.