### PR TITLE
Close code tag in live examples

### DIFF
--- a/site/src/pages/factories.md
+++ b/site/src/pages/factories.md
@@ -82,7 +82,7 @@ The `mdx-breadboard` package uses a `codeBlock` factory to provide live examples
         return <MDXBreadboard defaultSource={children} />
       }
       else {
-        return <pre {...props}><code dangerouslySetInnerHTML={{ __html: children }} /</pre>
+        return <pre {...props}><code dangerouslySetInnerHTML={{ __html: children }} /></pre>
       }
     }
   }}


### PR DESCRIPTION
Noticed this when walking through the documentation.