### PR TITLE
Set filename when transforming the mdxTagImport chunk

### DIFF
--- a/packages/mdx.macro/mdx.macro.js
+++ b/packages/mdx.macro/mdx.macro.js
@@ -57,6 +57,7 @@ function mdxMacro({ babel, references, state }) {
       `import { MDXTag } from '@mdx-js/tag'`,
       {
         ast: true,
+        filename: "mdx.macro/mdxTagImport.js"
       }
     )
     program.node.body.unshift(mdxTagImport.ast.program.body[0])


### PR DESCRIPTION
If you don't do that, and the project uses the babel typescript preset… lots of problems happen. By setting the filename to something *.js it prevents the typescript preset from interfering with the transform.