### PR TITLE
import `<MDXTag>`

### DIFF
--- a/packages/mdx-loader/index.js
+++ b/packages/mdx-loader/index.js
@@ -46,6 +46,7 @@ module.exports = async function(source) {
   let code = `
 import React from 'react'
 import { mdx } from '@mdx-js/react'
+import { MDXTag } from '@mdx/tag'
 export const readingTime = ${JSON.stringify(estimatedReadingTime)}
 ${result}
 `

--- a/packages/mdx-loader/package.json
+++ b/packages/mdx-loader/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.0.20",
     "@mdx-js/react": "^1.0.20",
+    "@mdx-js/tag": "^0.20.3",
     "gray-matter": "^4.0.2",
     "hast-util-to-string": "^1.0.1",
     "loader-utils": "^1.1.0",


### PR DESCRIPTION
Without it, when I'm doing `tableOfContents()`, I've got

> `Uncaught ReferenceError: MDXTag is not defined`