### PR TITLE
Fix support for prismjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ mdx-util
     * Emoji support via [remark-emoji](https://www.npmjs.com/package/remark-emoji)
     * Image urls are automatically embedded as images via [remark-images](https://www.npmjs.com/package/remark-images)
     * All headings have `id` slugs added via [remark-slug](https://github.com/remarkjs/remark-slug)
-    * Code blocks have markup for syntax highlighting via [prismjs](https://prismjs.com/) and [rehype-prism](https://github.com/mapbox/rehype-prism). *Note: you'll still need to import the prism stylesheet yourself.*
+    * Code blocks have markup for syntax highlighting via [prismjs](https://prismjs.com/). *Note: you'll still need to import the prism stylesheet yourself.*
     * Front matter is exported on a `frontMatter` object via [gray-matter](https://github.com/jonschlinkert/gray-matter).
     * A table of contents object is exported on the `tableOfContents` object via [mdx-table-of-contents](./packages/mdx-table-of-contents).
 

--- a/packages/mdx-loader/prism/index.js
+++ b/packages/mdx-loader/prism/index.js
@@ -46,7 +46,7 @@ module.exports = options => {
 
     let code = nodeToString(node);
     try {
-      node.properties.className = (parent.properties.className || [])
+      parent.properties.className = (parent.properties.className || [])
         .concat('language-' + normalizedLanguage);
 
       node.properties['data-language'] = normalizedLanguage


### PR DESCRIPTION
Hi there,

I was using your mdx-loader package (Thanks!) and found that prisjms-highlighted code did not receive any background styling due to missing `language-xxx` classes on the `pre` tags. As you pointed out in your code comments, prismjs expects those language classes on the pre tags.

Also you are not using [rehype-prism](https://github.com/mapbox/rehype-prism) as far as I can see. So I took the liberty of removing it from the README.

Cheers