### PR TITLE
Fix copy of "language-xxx" class from code tag to pre tag

### DIFF
--- a/packages/mdx-loader/prism/index.js
+++ b/packages/mdx-loader/prism/index.js
@@ -46,7 +46,7 @@ module.exports = options => {
 
     let code = nodeToString(node);
     try {
-      node.properties.className = (parent.properties.className || [])
+      parent.properties.className = (parent.properties.className || [])
         .concat('language-' + normalizedLanguage);
 
       node.properties['data-language'] = normalizedLanguage


### PR DESCRIPTION
Hi there,

**Note**: I created a new PR which is the same as #58 but without the change to Readme as I saw now that my assumption wrt. rehype-prism was wrong.

**Original Message**
I was using your mdx-loader package (Thanks!) and found that prisjms-highlighted code did not receive any background styling due to missing language-xxx classes on the pre tags. As you pointed out in your code comments, prismjs expects those language classes on the pre tags.

~Also you are not using rehype-prism as far as I can see. So I took the liberty of removing it from the README.~

Cheers